### PR TITLE
Update structure

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Build
+build/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,11 +2,12 @@ FROM golang:latest
 
 WORKDIR /app
 
-COPY routes routes/
-COPY go.mod main.go ./
+COPY cmd cmd/
+COPY api api/
+COPY go.mod ./
 
-RUN go build -o main .
+RUN go build -o build/main cmd/main.go
 
 EXPOSE 8080
 
-CMD ["./main"]
+CMD ./build/main

--- a/server/api/health.go
+++ b/server/api/health.go
@@ -1,4 +1,4 @@
-package routes
+package api
 
 import (
 	"fmt"

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/j-dumbell/splendid/routes"
 	"net/http"
 	"strconv"
+
+	"github.com/j-dumbell/splendid/api"
 )
 
 func main() {
 	port := 8080
 	fmt.Println("Starting on port " + strconv.Itoa(port))
-	http.HandleFunc("/health", routes.Health)
-	http.ListenAndServe(":" + strconv.Itoa(port), nil)
+	http.HandleFunc("/health", api.Health)
+	http.ListenAndServe(":"+strconv.Itoa(port), nil)
 }
-


### PR DESCRIPTION
Using https://github.com/golang-standards/project-layout as a guide

- move `main.go` to `cmd/main.go`
- rename `routes` package to `api`
- build output goes into `build/`
- group inputs by type